### PR TITLE
Add `app` label to Helm Chart templates

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -34,6 +34,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "azurerator.labels" -}}
+app: {{ include "azurerator.name" . }}
 helm.sh/chart: {{ include "azurerator.chart" . }}
 {{ include "azurerator.selectorLabels" . }}
 {{- if .Chart.AppVersion }}


### PR DESCRIPTION
This makes it easier to select logs in systems like Grafana Loki as it is pre-indexed on app label.