### PR TITLE
fix: ignore NotFound error on Application updates

### DIFF
--- a/controllers/azureadapplication/azureadapplication_controller.go
+++ b/controllers/azureadapplication/azureadapplication_controller.go
@@ -307,6 +307,9 @@ func (r *Reconciler) UpdateApplication(ctx context.Context, app *v1.AzureAdAppli
 	existing := &v1.AzureAdApplication{}
 	err := r.Reader.Get(ctx, client.ObjectKey{Namespace: app.Namespace, Name: app.Name}, existing)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("get newest version of AzureAdApplication: %s", err)
 	}
 


### PR DESCRIPTION
We are using observing random errors in Azurerator logs from our e2e-tests. This is probably caused by resources deleted when Azurerator is trying to update the AzureAdApplication status. We typically get error message like this:

```
updating status fields: get newest version of AzureAdApplication: azureadapplications.nais.io \"auth-app\" not found
```

This minor patch just ignores `NotFound` errors to avoid this.