### PR TITLE
feat: manage federated identity credentials

### DIFF
--- a/charts/templates/secret.yaml
+++ b/charts/templates/secret.yaml
@@ -31,6 +31,8 @@ stringData:
           enabled: "{{ .Values.global.features.cleanupOrphans | default .Values.features.cleanupOrphans }}"
         custom-security-attributes:
           enabled: "{{ .Values.global.features.customSecurityAttributes.enabled | default .Values.features.customSecurityAttributes.enabled }}"
+        federated-credentials:
+          enabled: "{{ .Values.global.features.federatedCredentials.enabled | default .Values.features.federatedCredentials.enabled }}"
         groups-assignment:
           enabled: "{{ .Values.global.features.groupsAssignment.enabled | default .Values.features.groupsAssignment.enabled }}"
           {{- if .Values.features.groupsAssignment.allUsersGroupIDs }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -20,6 +20,8 @@ global:
     cleanupOrphans:
     customSecurityAttributes:
       enabled:
+    federatedCredentials:
+      enabled:
     groupsAssignment:
       enabled:
   google:
@@ -57,6 +59,8 @@ features:
     id:
   cleanupOrphans: false
   customSecurityAttributes:
+    enabled: false
+  federatedCredentials:
     enabled: false
   groupsAssignment:
     enabled: true

--- a/config/samples/azureadapplication.yaml
+++ b/config/samples/azureadapplication.yaml
@@ -15,6 +15,12 @@ spec:
     groups:
       - id: "00000000-0000-0000-0000-000000000000"
   groupMembershipClaims: "ApplicationGroup"
+  # Requires azure.features.federated-credentials.enabled=true.
+  federatedCredentials:
+    - name: github-actions
+      audience: api://AzureADTokenExchange
+      issuer: https://token.actions.githubusercontent.com
+      subject: repo:nais@29488289/azurerator@252177010:ref:refs/heads/master
   logoutUrl: "https://localhost:3000/oauth2/logout"
   preAuthorizedApplications:
     - application: myapp2

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,7 @@ Additionally, one of the following authentication methods must be configured:
 | `--azure.features.claims-mapping-policies.id`           | string   |                     | Claims-mapping policy ID                                               |
 | `--azure.features.cleanup-orphans.enabled`              | bool     | `false`             | Enable cleanup of orphaned resources                                   |
 | `--azure.features.custom-security-attributes.enabled`   | bool     | `false`             | Set custom security attributes on service principals                   |
+| `--azure.features.federated-credentials.enabled`        | bool     | `false`             | Manage federated identity credentials on applications                  |
 | `--azure.features.group-membership-claim.default`       | string   | `ApplicationGroup`  | Default group membership claim. Only affects new registrations         |
 | `--azure.features.groups-assignment.all-users-group-id` | strings  |                     | List of Group IDs containing all users in the tenant                   |
 | `--azure.features.groups-assignment.enabled`            | bool     | `false`             | Assign groups to applications                                          |

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -46,7 +46,7 @@ sequenceDiagram
 
 1. Developer applies an `AzureAdApplication` resource to the cluster.
 2. Azurerator detects the change and registers (or updates) the corresponding application in Entra ID.
-3. Credentials, service principal, delegated permissions, and pre-authorized clients are configured.
+3. Federated credentials, credentials, service principal, delegated permissions, and pre-authorized clients are configured.
 4. A Kubernetes `Secret` is created with the credentials and metadata the application needs at runtime.
 5. On deletion of the resource, the Entra ID application is cleaned up (unless `azure.nais.io/preserve=true`).
 
@@ -68,9 +68,10 @@ The following is a detailed overview of operations performed per reconciliation.
     - [1.4 Service Principal](#14-service-principal)
     - [1.5 Delegated Permissions](#15-delegated-permissions)
     - [1.6 Credentials](#16-credentials)
-    - [1.7 Group Assignment](#17-group-assignment)
-    - [1.8 Single-Page Applications](#18-single-page-applications)
-    - [1.9 Principal Assignment Required](#19-principal-assignment-required)
+    - [1.7 Federated Identity Credentials](#17-federated-identity-credentials)
+    - [1.8 Group Assignment](#18-group-assignment)
+    - [1.9 Single-Page Applications](#19-single-page-applications)
+    - [1.10 Principal Assignment Required](#110-principal-assignment-required)
 - [2 Existing applications](#2-existing-applications)
     - [2.1 Credential Rotation](#21-credential-rotation)
 - [3 Cluster Resources](#3-cluster-resources)
@@ -163,7 +164,7 @@ to obtain access tokens intended for the application. This authorization is enfo
 the `on_behalf_of` flow.
 
 It is _not_ enforced for the `client_credentials` flow unless assignment requirement is explicitly enabled for the
-application (see [1.9 Principal Assignment Required](#19-principal-assignment-required)).
+application (see [1.10 Principal Assignment Required](#110-principal-assignment-required)).
 
 These are registered according to the list of applications defined in `spec.preAuthorizedApplications[]` in
 the `AzureAdApplication` resource, with the following caveats:
@@ -220,7 +221,22 @@ These fields thus denote the currently used set of credentials.
 See <https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#option-2-create-a-new-application-secret>
 for details.
 
-### 1.7 Group Assignment
+### 1.7 Federated Identity Credentials
+
+Federated identity credential reconciliation is disabled unless
+`azure.features.federated-credentials.enabled` is set to `true`.
+Resources must be resynchronized after this feature is enabled because changing the flag does not change their
+synchronization hashes.
+
+`spec.federatedCredentials[]` defines the authoritative set of federated identity credentials. Each combination of
+`issuer` and `subject` must be unique.
+
+Azurerator creates missing credentials, updates changed credentials where possible, and deletes credentials absent from
+the list. This includes credentials created outside Azurerator. Some conflicting changes require deletion and recreation.
+
+See <https://learn.microsoft.com/en-us/graph/api/resources/federatedidentitycredential> for details.
+
+### 1.8 Group Assignment
 
 `spec.claims.groups[]` is a list of Object IDs that reference Entra ID groups to be assigned to the _Service Principal_
 belonging to the `AzureAdApplication`.
@@ -241,13 +257,13 @@ If `spec.allowAllUsers` is set to `true`, the group configured by the
 `azure.features.groups-assignment.all-users-group-id` will be assigned to the application. This group should contain
 all users that should have access to the application by default.
 
-### 1.8 Single-Page Applications
+### 1.9 Single-Page Applications
 
 Entra ID supports the [OAuth 2.0 Auth Code Flow with PKCE](https://learn.microsoft.com/en-us/entra/identity-platform/scenario-spa-overview) for logins from client-side/browser single-page-applications.
 However, the support for this must be explicitly enabled to avoid issues with CORS by setting
 `spec.singlePageApplication` to `true`.
 
-### 1.9 Principal Assignment Required
+### 1.10 Principal Assignment Required
 
 The `AppRoleAssignmentRequired` property denotes whether Entra ID should enforce/require that principals are explicitly
 assigned to the `AzureAdApplication` when using the application in a Web API flow such as the OAuth 2.0 Client Credentials flow.
@@ -256,7 +272,7 @@ assigned to the `AzureAdApplication` when using the application in a Web API flo
 
 Defaults to `false`.
 
-Enabling this will also require the explicit assignment of any end-user that should be able to log in to the application — either directly or through a [group](#17-group-assignment).
+Enabling this will also require the explicit assignment of any end-user that should be able to log in to the application — either directly or through a [group](#18-group-assignment).
 It will consequently also affect any use of the on-behalf-of flow - which involves end-users, and thus follows the same restriction as described for the login usecase.
 
 ## 2 Existing applications

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.4
 	github.com/google/uuid v1.6.0
-	github.com/nais/liberator v0.0.0-20260817132853-9ab99fe72655
+	github.com/nais/liberator v0.0.0-20260821110711-4a88a485bafc
 	github.com/nais/msgraph.go v0.2.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/sethvargo/go-retry v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nais/liberator v0.0.0-20260817132853-9ab99fe72655 h1:CpJ2PToJU8HPcBBdA643j/8lcS+qp2AQ+KkD4SW0F28=
-github.com/nais/liberator v0.0.0-20260817132853-9ab99fe72655/go.mod h1:QBMwZsrBxJq8DRckVMFNvsmbTp6cykDM3lCuJYGjVrE=
+github.com/nais/liberator v0.0.0-20260821110711-4a88a485bafc h1:x6if8CRIVlevhgNaueLHhOWr8fiB9OQLMLDcPtUWyiQ=
+github.com/nais/liberator v0.0.0-20260821110711-4a88a485bafc/go.mod h1:bC52GROnYJ/LNS/hsYnGgOFp9ZcbJDdOOrz8aqZvKyw=
 github.com/nais/msgraph.go v0.2.0 h1:eBSiNQspYMptn/sgzLDiVCf/UpijScam8M6ZYY5woHI=
 github.com/nais/msgraph.go v0.2.0/go.mod h1:K/5QCA8Rwg27gyEHvhRjFZjHS+xrbdNujX72qMqRmg4=
 github.com/nais/pgrator/pkg/api v0.0.0-20260702113208-b469e505b1d5 h1:fOWAxiK6MoEX4rwAzxilRXYjTxMSm66D3zsInrahEkg=

--- a/pkg/azure/client/application/application.go
+++ b/pkg/azure/client/application/application.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nais/azureator/pkg/azure"
 	"github.com/nais/azureator/pkg/azure/client/application/approle"
+	"github.com/nais/azureator/pkg/azure/client/application/federatedcredential"
 	"github.com/nais/azureator/pkg/azure/client/application/identifieruri"
 	"github.com/nais/azureator/pkg/azure/client/application/optionalclaims"
 	"github.com/nais/azureator/pkg/azure/client/application/permissionscope"
@@ -33,6 +34,7 @@ var IsManagedCache = cache.New[azure.ClientId, bool]()
 
 type Application interface {
 	AppRoles() approle.AppRoles
+	FederatedCredential() federatedcredential.FederatedCredential
 	IdentifierUri() identifieruri.IdentifierUri
 	OAuth2PermissionScopes() permissionscope.OAuth2PermissionScope
 	Owners() owners.Owners
@@ -61,6 +63,10 @@ func NewApplication(runtimeClient azure.RuntimeClient) Application {
 
 func (a application) AppRoles() approle.AppRoles {
 	return approle.NewAppRoles()
+}
+
+func (a application) FederatedCredential() federatedcredential.FederatedCredential {
+	return federatedcredential.NewFederatedCredential(a.RuntimeClient)
 }
 
 func (a application) IdentifierUri() identifieruri.IdentifierUri {

--- a/pkg/azure/client/application/federatedcredential/federatedcredential.go
+++ b/pkg/azure/client/application/federatedcredential/federatedcredential.go
@@ -1,0 +1,163 @@
+package federatedcredential
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nais/azureator/pkg/azure"
+	"github.com/nais/azureator/pkg/transaction"
+	v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
+	msgraph "github.com/nais/msgraph.go/v1.0"
+)
+
+type FederatedCredential interface {
+	Process(tx transaction.Transaction) error
+}
+
+type federatedCredential struct {
+	azure.RuntimeClient
+}
+
+func NewFederatedCredential(client azure.RuntimeClient) FederatedCredential {
+	return federatedCredential{RuntimeClient: client}
+}
+
+func (f federatedCredential) Process(tx transaction.Transaction) error {
+	objectID := tx.Instance.GetObjectId()
+	collection := f.GraphClient().Applications().ID(objectID).FederatedIdentityCredentials()
+	logger := tx.Logger.WithField("subsystem", "federatedcredential")
+
+	existing, err := collection.Request().GetN(tx.Ctx, f.MaxNumberOfPagesToFetch())
+	if err != nil {
+		return fmt.Errorf("listing federated identity credentials for application: %w", err)
+	}
+
+	changes, err := diff(existing, tx.Instance.Spec.FederatedCredentials)
+	if err != nil {
+		return err
+	}
+
+	// Deletions free unique issuer-subject pairs before updates and creations claim them.
+	for _, credential := range changes.toDelete {
+		time.Sleep(f.DelayIntervalBetweenModifications())
+		if err := collection.ID(*credential.ID).Request().Delete(tx.Ctx); err != nil {
+			return fmt.Errorf("deleting federated identity credential %q: %w", stringValue(credential.Name), err)
+		}
+		logger.Debugf("deleted federated identity credential %q", stringValue(credential.Name))
+	}
+
+	for _, update := range changes.toUpdate {
+		time.Sleep(f.DelayIntervalBetweenModifications())
+		credential := fromDesired(update.desired)
+		// Names are immutable and must not be included in a Graph PATCH request.
+		credential.Name = nil
+		if err := collection.ID(update.id).Request().Update(tx.Ctx, &credential); err != nil {
+			return fmt.Errorf("updating federated identity credential %q: %w", update.desired.Name, err)
+		}
+		logger.Debugf("updated federated identity credential %q", update.desired.Name)
+	}
+
+	for _, desired := range changes.toCreate {
+		credential := fromDesired(desired)
+		time.Sleep(f.DelayIntervalBetweenModifications())
+		if _, err := collection.Request().Add(tx.Ctx, &credential); err != nil {
+			return fmt.Errorf("creating federated identity credential %q: %w", desired.Name, err)
+		}
+		logger.Debugf("created federated identity credential %q", desired.Name)
+	}
+
+	return nil
+}
+
+type (
+	changes struct {
+		toCreate []v1.AzureAdFederatedCredential
+		toUpdate []credentialUpdate
+		toDelete []msgraph.FederatedIdentityCredential
+	}
+	credentialUpdate struct {
+		id      string
+		desired v1.AzureAdFederatedCredential
+	}
+	issuerSubject struct {
+		issuer  string
+		subject string
+	}
+)
+
+func diff(existing []msgraph.FederatedIdentityCredential, desired []v1.AzureAdFederatedCredential) (changes, error) {
+	desiredByName := make(map[string]v1.AzureAdFederatedCredential, len(desired))
+	for _, credential := range desired {
+		desiredByName[credential.Name] = credential
+	}
+
+	existingByName := make(map[string]msgraph.FederatedIdentityCredential, len(existing))
+	ownerOfPair := make(map[issuerSubject]string, len(existing))
+	for _, credential := range existing {
+		name := stringValue(credential.Name)
+		existingByName[name] = credential
+		ownerOfPair[issuerSubject{issuer: stringValue(credential.Issuer), subject: stringValue(credential.Subject)}] = name
+	}
+
+	result := changes{}
+	recreate := make(map[string]struct{})
+	for _, credential := range desired {
+		current, found := existingByName[credential.Name]
+		if !found {
+			result.toCreate = append(result.toCreate, credential)
+			continue
+		}
+		if matches(current, credential) {
+			continue
+		}
+		if current.ID == nil {
+			return changes{}, fmt.Errorf("updating federated identity credential %q: missing Graph ID", credential.Name)
+		}
+
+		owner, held := ownerOfPair[issuerSubject{issuer: credential.Issuer, subject: credential.Subject}]
+		_, ownerRemains := desiredByName[owner]
+		if held && owner != credential.Name && ownerRemains {
+			recreate[credential.Name] = struct{}{}
+			result.toCreate = append(result.toCreate, credential)
+			continue
+		}
+		result.toUpdate = append(result.toUpdate, credentialUpdate{id: *current.ID, desired: credential})
+	}
+
+	for _, credential := range existing {
+		name := stringValue(credential.Name)
+		_, remains := desiredByName[name]
+		_, replaced := recreate[name]
+		if remains && !replaced {
+			continue
+		}
+		if credential.ID == nil {
+			return changes{}, fmt.Errorf("deleting federated identity credential %q: missing Graph ID", name)
+		}
+		result.toDelete = append(result.toDelete, credential)
+	}
+
+	return result, nil
+}
+
+func fromDesired(desired v1.AzureAdFederatedCredential) msgraph.FederatedIdentityCredential {
+	return msgraph.FederatedIdentityCredential{
+		Name:      new(desired.Name),
+		Audiences: []string{desired.Audience},
+		Issuer:    new(desired.Issuer),
+		Subject:   new(desired.Subject),
+	}
+}
+
+func matches(existing msgraph.FederatedIdentityCredential, desired v1.AzureAdFederatedCredential) bool {
+	return stringValue(existing.Issuer) == desired.Issuer &&
+		stringValue(existing.Subject) == desired.Subject &&
+		len(existing.Audiences) == 1 && existing.Audiences[0] == desired.Audience
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/pkg/azure/client/application/federatedcredential/federatedcredential_test.go
+++ b/pkg/azure/client/application/federatedcredential/federatedcredential_test.go
@@ -1,0 +1,222 @@
+package federatedcredential
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	msgraph "github.com/nais/msgraph.go/v1.0"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	azureconfig "github.com/nais/azureator/pkg/config"
+	"github.com/nais/azureator/pkg/transaction"
+	v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
+)
+
+func TestProcess(t *testing.T) {
+	t.Run("reconciles credentials", func(t *testing.T) {
+		existing := []msgraph.FederatedIdentityCredential{
+			credential("kept", "kept-id", "audience", "issuer", "subject"),
+			credential("first", "first-id", "first-audience", "first-issuer", "first-subject"),
+			credential("second", "second-id", "second-audience", "second-issuer", "second-subject"),
+			credential("deleted", "deleted-id", "audience", "issuer", "subject"),
+		}
+		desired := []v1.AzureAdFederatedCredential{
+			{Name: "kept", Audience: "audience", Issuer: "issuer", Subject: "subject"},
+			{Name: "first", Audience: "new-first-audience", Issuer: "new-first-issuer", Subject: "new-first-subject"},
+			{Name: "second", Audience: "new-second-audience", Issuer: "new-second-issuer", Subject: "new-second-subject"},
+			{Name: "created", Audience: "audience", Issuer: "issuer", Subject: "subject"},
+		}
+		requests, err := processRequests(t, existing, desired)
+
+		require.NoError(t, err)
+		assertRequests(t, requests,
+			deleteRequest("deleted-id"),
+			patchRequest("first-id", map[string]any{
+				"audiences": []any{"new-first-audience"}, "issuer": "new-first-issuer", "subject": "new-first-subject",
+			}),
+			patchRequest("second-id", map[string]any{
+				"audiences": []any{"new-second-audience"}, "issuer": "new-second-issuer", "subject": "new-second-subject",
+			}),
+			postRequest(map[string]any{
+				"name": "created", "audiences": []any{"audience"}, "issuer": "issuer", "subject": "subject",
+			}),
+		)
+	})
+}
+
+func TestDiff(t *testing.T) {
+	t.Run("replaces credentials when issuer and subject pairs are swapped", func(t *testing.T) {
+		existing := []msgraph.FederatedIdentityCredential{
+			credential("second", "second-id", "audience", "second-issuer", "second-subject"),
+			credential("first", "first-id", "audience", "first-issuer", "first-subject"),
+		}
+		desired := []v1.AzureAdFederatedCredential{
+			{Name: "first", Audience: "audience", Issuer: "second-issuer", Subject: "second-subject"},
+			{Name: "second", Audience: "audience", Issuer: "first-issuer", Subject: "first-subject"},
+		}
+		actual, err := diff(existing, desired)
+
+		require.NoError(t, err)
+		assert.Equal(t, changes{toDelete: existing, toCreate: desired}, actual)
+	})
+
+	t.Run("deletes an obsolete conflict before updating", func(t *testing.T) {
+		existing := []msgraph.FederatedIdentityCredential{
+			credential("kept", "kept-id", "audience", "old-issuer", "old-subject"),
+			credential("obsolete", "obsolete-id", "audience", "new-issuer", "new-subject"),
+		}
+		desired := []v1.AzureAdFederatedCredential{
+			{Name: "kept", Audience: "audience", Issuer: "new-issuer", Subject: "new-subject"},
+		}
+		actual, err := diff(existing, desired)
+
+		require.NoError(t, err)
+		assert.Equal(t, changes{
+			toDelete: existing[1:],
+			toUpdate: []credentialUpdate{{id: "kept-id", desired: desired[0]}},
+		}, actual)
+	})
+
+	t.Run("recreates a credential whose desired pair is held by another desired credential", func(t *testing.T) {
+		existing := []msgraph.FederatedIdentityCredential{
+			credential("first", "first-id", "audience", "first-issuer", "first-subject"),
+			credential("second", "second-id", "audience", "second-issuer", "second-subject"),
+		}
+		desired := []v1.AzureAdFederatedCredential{
+			{Name: "first", Audience: "audience", Issuer: "third-issuer", Subject: "third-subject"},
+			{Name: "second", Audience: "audience", Issuer: "first-issuer", Subject: "first-subject"},
+		}
+		actual, err := diff(existing, desired)
+
+		require.NoError(t, err)
+		assert.Equal(t, changes{
+			toCreate: desired[1:],
+			toUpdate: []credentialUpdate{{id: "first-id", desired: desired[0]}},
+			toDelete: existing[1:],
+		}, actual)
+	})
+
+	t.Run("empty spec deletes all existing credentials", func(t *testing.T) {
+		existing := []msgraph.FederatedIdentityCredential{
+			credential("first", "first-id", "audience", "issuer", "subject"),
+			credential("second", "second-id", "audience", "issuer", "subject"),
+		}
+		actual, err := diff(existing, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, changes{toDelete: existing}, actual)
+	})
+
+	t.Run("updates a credential with incomplete Graph fields", func(t *testing.T) {
+		existing := []msgraph.FederatedIdentityCredential{{
+			Entity: msgraph.Entity{ID: new("existing-id")},
+			Name:   new("existing"),
+		}}
+		desired := []v1.AzureAdFederatedCredential{
+			{Name: "existing", Audience: "audience", Issuer: "issuer", Subject: "subject"},
+		}
+		actual, err := diff(existing, desired)
+
+		require.NoError(t, err)
+		assert.Equal(t, changes{toUpdate: []credentialUpdate{{id: "existing-id", desired: desired[0]}}}, actual)
+	})
+}
+
+const collectionPath = "/v1.0/applications/application-id/federatedIdentityCredentials"
+
+type request struct {
+	Method string
+	Path   string
+	Body   map[string]any
+}
+
+func processRequests(t *testing.T, existing []msgraph.FederatedIdentityCredential, desired []v1.AzureAdFederatedCredential) ([]request, error) {
+	t.Helper()
+	var requests []request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var body map[string]any
+		if len(rawBody) > 0 && !assert.NoError(t, json.Unmarshal(rawBody, &body)) {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		requests = append(requests, request{Method: r.Method, Path: r.URL.Path, Body: body})
+
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"value": existing}))
+			return
+		}
+		if r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			assert.NoError(t, json.NewEncoder(w).Encode(msgraph.FederatedIdentityCredential{}))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	baseURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	httpClient := &http.Client{Transport: rewriteTransport{baseURL: baseURL, next: http.DefaultTransport}}
+	runtime := testRuntimeClient{graph: msgraph.NewClient(httpClient)}
+	instance := &v1.AzureAdApplication{Status: v1.AzureAdApplicationStatus{ObjectId: "application-id"}, Spec: v1.AzureAdApplicationSpec{FederatedCredentials: desired}}
+	tx := transaction.Transaction{Ctx: t.Context(), Instance: instance, Logger: *log.NewEntry(log.New())}
+	err = NewFederatedCredential(runtime).Process(tx)
+	return requests, err
+}
+
+func assertRequests(t *testing.T, actual []request, expected ...request) {
+	t.Helper()
+	expected = append([]request{{Method: http.MethodGet, Path: collectionPath}}, expected...)
+	assert.Equal(t, expected, actual)
+}
+
+func deleteRequest(id string) request {
+	return request{Method: http.MethodDelete, Path: collectionPath + "/" + id}
+}
+
+func patchRequest(id string, body map[string]any) request {
+	return request{Method: http.MethodPatch, Path: collectionPath + "/" + id, Body: body}
+}
+
+func postRequest(body map[string]any) request {
+	return request{Method: http.MethodPost, Path: collectionPath, Body: body}
+}
+
+func credential(name, id, audience, issuer, subject string) msgraph.FederatedIdentityCredential {
+	return msgraph.FederatedIdentityCredential{Entity: msgraph.Entity{ID: new(id)}, Name: new(name), Audiences: []string{audience}, Issuer: new(issuer), Subject: new(subject)}
+}
+
+type rewriteTransport struct {
+	baseURL *url.URL
+	next    http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.URL.Scheme = t.baseURL.Scheme
+	r.URL.Host = t.baseURL.Host
+	return t.next.RoundTrip(r)
+}
+
+type testRuntimeClient struct {
+	graph *msgraph.GraphServiceRequestBuilder
+}
+
+func (t testRuntimeClient) Config() *azureconfig.AzureConfig                 { return &azureconfig.AzureConfig{} }
+func (t testRuntimeClient) GraphClient() *msgraph.GraphServiceRequestBuilder { return t.graph }
+func (t testRuntimeClient) HttpClient() *http.Client                         { return http.DefaultClient }
+func (t testRuntimeClient) DelayIntervalBetweenModifications() time.Duration { return 0 }
+func (t testRuntimeClient) MaxNumberOfPagesToFetch() int                     { return 1 }

--- a/pkg/azure/client/client.go
+++ b/pkg/azure/client/client.go
@@ -316,6 +316,12 @@ func (c Client) process(tx transaction.Transaction, app *msgraph.Application) (*
 		}
 	}
 
+	if c.config.Features.FederatedCredentials.Enabled {
+		if err := c.Application().FederatedCredential().Process(tx); err != nil {
+			return nil, fmt.Errorf("processing federated identity credentials: %w", err)
+		}
+	}
+
 	return &processResult{
 		preAuthorizedApps: *preAuthApps,
 		permissions:       perms,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,6 +62,7 @@ type AzureFeatures struct {
 	ClaimsMappingPolicies     ClaimsMappingPolicies     `json:"claims-mapping-policies"`
 	CleanupOrphans            CleanupOrphans            `json:"cleanup-orphans"`
 	CustomSecurityAttributes  CustomSecurityAttributes  `json:"custom-security-attributes"`
+	FederatedCredentials      FederatedCredentials      `json:"federated-credentials"`
 	GroupsAssignment          GroupsAssignment          `json:"groups-assignment"`
 	GroupMembershipClaim      GroupMembershipClaim      `json:"group-membership-claim"`
 }
@@ -80,6 +81,10 @@ type CleanupOrphans struct {
 }
 
 type CustomSecurityAttributes struct {
+	Enabled bool `json:"enabled"`
+}
+
+type FederatedCredentials struct {
 	Enabled bool `json:"enabled"`
 }
 
@@ -133,6 +138,7 @@ const (
 	AzureFeaturesClaimsMappingPoliciesEnabled     = "azure.features.claims-mapping-policies.enabled"
 	AzureFeaturesClaimsMappingPoliciesID          = "azure.features.claims-mapping-policies.id"
 	AzureFeaturesCustomSecurityAttributesEnabled  = "azure.features.custom-security-attributes.enabled"
+	AzureFeaturesFederatedCredentialsEnabled      = "azure.features.federated-credentials.enabled"
 	AzureFeaturesGroupsAssignmentEnabled          = "azure.features.groups-assignment.enabled"
 	AzureFeaturesGroupsAllUsersGroupId            = "azure.features.groups-assignment.all-users-group-id"
 	AzureFeaturesGroupMembershipClaimDefault      = "azure.features.group-membership-claim.default"
@@ -175,6 +181,7 @@ func init() {
 	flag.Bool(AzureFeaturesClaimsMappingPoliciesEnabled, false, "Assign custom claims-mapping policies to a service principal")
 	flag.String(AzureFeaturesClaimsMappingPoliciesID, "", "Claims-mapping policy ID for custom claims mapping")
 	flag.Bool(AzureFeaturesCustomSecurityAttributesEnabled, false, "Set custom security attributes on service principals (attribute set of 'Applications':'ManagedBy':'NAIS')")
+	flag.Bool(AzureFeaturesFederatedCredentialsEnabled, false, "Manage federated identity credentials on applications.")
 	flag.Bool(AzureFeaturesGroupsAssignmentEnabled, false, "Assign groups to applications")
 	flag.StringSlice(AzureFeaturesGroupsAllUsersGroupId, []string{}, "List of Group IDs that contains all users in the tenant. Assigned to all applications by default unless 'allowAllUsers' is set to false in the custom resource.")
 	flag.String(AzureFeaturesGroupMembershipClaimDefault, groupmembershipclaim.ApplicationGroup, "Default group membership claim for Azure AD apps. Only affects new registrations.")


### PR DESCRIPTION
Add reconciliation of federated identity credentials for applications in Entra ID behind the `azure.features.federated-credentials.enabled` feature flag (defaults to false).

When enabled, `spec.federatedCredentials` is authoritative. An empty list means that all existing federated credentials are removed.

Fixes #6.
Depends on https://github.com/nais/liberator/pull/343.